### PR TITLE
Add devcontainer automation & env-based YouTube auth

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8-slim
+
+# Install system packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    imagemagick \
+    cron \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+WORKDIR /workspaces/TheDailySnap

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "TheDailySnap",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "postStartCommand": "bash .devcontainer/setup-cron.sh",
+    "containerEnv": {
+        "OPENAI_API_KEY": "",
+        "ELEVENLABS_API_KEY": "",
+        "ELEVENLABS_VOICE_ID": "",
+        "YOUTUBE_CLIENT_ID": "",
+        "YOUTUBE_CLIENT_SECRET": "",
+        "YOUTUBE_PROJECT_ID": "",
+        "YOUTUBE_AUTH_URI": "",
+        "YOUTUBE_TOKEN_URI": "",
+        "YOUTUBE_AUTH_PROVIDER_X509_CERT_URL": "",
+        "YOUTUBE_REDIRECT_URIS": "",
+        "YOUTUBE_TOKEN_JSON": "",
+        "GOOGLE_APPLICATION_CREDENTIALS": "",
+        "CRON_TIME": "0 2 * * *"
+    }
+}

--- a/.devcontainer/setup-cron.sh
+++ b/.devcontainer/setup-cron.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+ENV_FILE="$HOME/.news_env.sh"
+{
+  echo "#!/bin/bash"
+  for var in OPENAI_API_KEY ELEVENLABS_API_KEY ELEVENLABS_VOICE_ID \
+      YOUTUBE_CLIENT_ID YOUTUBE_CLIENT_SECRET YOUTUBE_PROJECT_ID \
+      YOUTUBE_AUTH_URI YOUTUBE_TOKEN_URI YOUTUBE_AUTH_PROVIDER_X509_CERT_URL \
+      YOUTUBE_REDIRECT_URIS YOUTUBE_TOKEN_JSON GOOGLE_APPLICATION_CREDENTIALS; do
+    if [ -n "${!var}" ]; then
+      echo "export $var=\"${!var}\""
+    fi
+  done
+} > "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+CRON_TIME=${CRON_TIME:-"0 2 * * *"}
+CRON_FILE=/etc/cron.d/news_shorts
+echo "CRON_TZ=UTC" > "$CRON_FILE"
+echo "$CRON_TIME bash -c 'source $ENV_FILE && cd /workspaces/TheDailySnap && python news_shorts.py >> /workspaces/TheDailySnap/cron.log 2>&1'" >> "$CRON_FILE"
+chmod 0644 "$CRON_FILE"
+crontab "$CRON_FILE"
+service cron start

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ output_v7_smooth/
 # Credentials and tokens
 client_secrets.json
 token.json
+cron.log
 
 # OS files
 .DS_Store

--- a/news_shorts.py
+++ b/news_shorts.py
@@ -1,0 +1,4 @@
+from news_shorts.pipeline import main
+
+if __name__ == "__main__":
+    main()

--- a/news_shorts/config.py
+++ b/news_shorts/config.py
@@ -3,6 +3,9 @@ import os
 import time
 from dotenv import load_dotenv
 
+import json
+import tempfile
+
 load_dotenv()
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -13,14 +16,45 @@ ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
 ELEVENLABS_VOICE_ID = os.getenv("ELEVENLABS_VOICE_ID")
 USE_ELEVENLABS = bool(ELEVENLABS_API_KEY and ELEVENLABS_VOICE_ID)
 
+# YouTube credentials from environment
+YOUTUBE_CLIENT_ID = os.getenv("YOUTUBE_CLIENT_ID")
+YOUTUBE_CLIENT_SECRET = os.getenv("YOUTUBE_CLIENT_SECRET")
+YOUTUBE_PROJECT_ID = os.getenv("YOUTUBE_PROJECT_ID")
+YOUTUBE_AUTH_URI = os.getenv("YOUTUBE_AUTH_URI")
+YOUTUBE_TOKEN_URI = os.getenv("YOUTUBE_TOKEN_URI")
+YOUTUBE_AUTH_PROVIDER_X509_CERT_URL = os.getenv("YOUTUBE_AUTH_PROVIDER_X509_CERT_URL")
+YOUTUBE_REDIRECT_URIS = os.getenv("YOUTUBE_REDIRECT_URIS")
+YOUTUBE_TOKEN_JSON = os.getenv("YOUTUBE_TOKEN_JSON")
+
 # TTS configuration
 TTS_MODEL = "tts-1-hd"
 TTS_VOICE = "ash"  # sarcastic Indian accent
 SPEEDUP = 1.1  # 10% faster pacing
 
 SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
-CLIENT_SECRETS_FILE = "client_secrets.json"
-TOKEN_FILE = "token.json"
+CLIENT_SECRETS_FILE = os.path.join(tempfile.gettempdir(), "client_secrets.json")
+TOKEN_FILE = os.path.join(tempfile.gettempdir(), "token.json")
+
+
+def write_client_secrets() -> None:
+    """Create client_secrets.json from environment variables if provided."""
+    if YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET:
+        data = {
+            "installed": {
+                "client_id": YOUTUBE_CLIENT_ID,
+                "client_secret": YOUTUBE_CLIENT_SECRET,
+                "project_id": YOUTUBE_PROJECT_ID or "",
+                "auth_uri": YOUTUBE_AUTH_URI or "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": YOUTUBE_TOKEN_URI or "https://oauth2.googleapis.com/token",
+                "auth_provider_x509_cert_url": YOUTUBE_AUTH_PROVIDER_X509_CERT_URL or "https://www.googleapis.com/oauth2/v1/certs",
+                "redirect_uris": YOUTUBE_REDIRECT_URIS.split(",") if YOUTUBE_REDIRECT_URIS else [
+                    "urn:ietf:wg:oauth:2.0:oob",
+                    "http://localhost",
+                ],
+            }
+        }
+        with open(CLIENT_SECRETS_FILE, "w") as f:
+            json.dump(data, f)
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 BACKGROUND_IMAGE = os.path.join(MODULE_DIR, "..", "assets", "background_fullframe.png")

--- a/news_shorts/youtube_client.py
+++ b/news_shorts/youtube_client.py
@@ -1,5 +1,7 @@
 import os
 import datetime
+import json
+import tempfile
 from typing import List, Dict
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
@@ -12,17 +14,43 @@ Article = Dict[str, str]
 
 
 def get_youtube_service():
+    config.write_client_secrets()
     creds = None
-    if os.path.exists(config.TOKEN_FILE):
+
+    if config.YOUTUBE_TOKEN_JSON:
+        creds = Credentials.from_authorized_user_info(json.loads(config.YOUTUBE_TOKEN_JSON), config.SCOPES)
+        if creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+    elif os.path.exists(config.TOKEN_FILE):
         creds = Credentials.from_authorized_user_file(config.TOKEN_FILE, config.SCOPES)
+
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(config.CLIENT_SECRETS_FILE, config.SCOPES)
+            if config.YOUTUBE_CLIENT_ID and config.YOUTUBE_CLIENT_SECRET:
+                data = {
+                    "installed": {
+                        "client_id": config.YOUTUBE_CLIENT_ID,
+                        "client_secret": config.YOUTUBE_CLIENT_SECRET,
+                        "project_id": config.YOUTUBE_PROJECT_ID or "",
+                        "auth_uri": config.YOUTUBE_AUTH_URI or "https://accounts.google.com/o/oauth2/auth",
+                        "token_uri": config.YOUTUBE_TOKEN_URI or "https://oauth2.googleapis.com/token",
+                        "auth_provider_x509_cert_url": config.YOUTUBE_AUTH_PROVIDER_X509_CERT_URL or "https://www.googleapis.com/oauth2/v1/certs",
+                        "redirect_uris": config.YOUTUBE_REDIRECT_URIS.split(",") if config.YOUTUBE_REDIRECT_URIS else ["urn:ietf:wg:oauth:2.0:oob", "http://localhost"],
+                    }
+                }
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+                json.dump(data, tmp)
+                tmp.flush()
+                flow = InstalledAppFlow.from_client_secrets_file(tmp.name, config.SCOPES)
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(config.CLIENT_SECRETS_FILE, config.SCOPES)
             creds = flow.run_local_server(port=0)
-        with open(config.TOKEN_FILE, "w") as f:
-            f.write(creds.to_json())
+        if not config.YOUTUBE_TOKEN_JSON:
+            with open(config.TOKEN_FILE, "w") as f:
+                f.write(creds.to_json())
+
     return build("youtube", "v3", credentials=creds)
 
 


### PR DESCRIPTION
## Summary
- add Dockerfile for Python 3.8 with ffmpeg and cron
- configure devcontainer with environment placeholders and cron job
- script to setup cron using Codespaces secrets
- dynamically build `client_secrets.json` and load token from env
- helper `news_shorts.py` runner
- ignore cron log

## Testing
- `python -m py_compile news_shorts/*.py news_shorts.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dab83f9e08320b58977d013d6c013