### PR TITLE
Fix youtube upload temp file

### DIFF
--- a/news_shorts/youtube_client.py
+++ b/news_shorts/youtube_client.py
@@ -40,7 +40,11 @@ def get_youtube_service():
                         "redirect_uris": config.YOUTUBE_REDIRECT_URIS.split(",") if config.YOUTUBE_REDIRECT_URIS else ["urn:ietf:wg:oauth:2.0:oob", "http://localhost"],
                     }
                 }
-                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+                # NamedTemporaryFile opens in binary mode by default which
+                # causes json.dump() to fail on Python 3. We explicitly open
+                # the file in text mode so json.dump writes str data without
+                # raising a TypeError.
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json", mode="w", encoding="utf-8")
                 json.dump(data, tmp)
                 tmp.flush()
                 flow = InstalledAppFlow.from_client_secrets_file(tmp.name, config.SCOPES)


### PR DESCRIPTION
## Summary
- ensure temporary file for OAuth client secrets is opened in text mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f94ed98fc8320a03e41bc9aabfe6b