### PR TITLE
Add Hindi shorts generation, remove summary video

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An intelligent news aggregation and video generation system that creates engagin
 - **YouTube Integration**: Automatic upload to YouTube with proper metadata
 - **Content Management**: Intelligent ranking and categorization of news articles
 - **Parallel Processing**: Optimized for speed with concurrent video processing
-- **Daily Summary Video**: Automatically creates and uploads an end-of-day recap
+- **Hindi Video**: Generates a second video in Hinglish with Hindi voice-over
 
 ## 📋 Prerequisites
 
@@ -130,13 +130,12 @@ python -m news_shorts
 2. **Content Analysis**: Uses AI to filter and rank articles
 3. **Script Generation**: Creates engaging scripts in English (optional Hindi voice-over)
 4. **Audio Generation**: Uses OpenAI or Google TTS by default, switching to ElevenLabs when configured
-5. **Video Creation**: Generates vertical videos with text overlays
+5. **Video Creation**: Generates vertical videos with text overlays in English and Hindi
 6. **YouTube Upload**: Automatically uploads videos to YouTube
-7. **Daily Summary**: Creates a brief recap video of the day's stories
 
 ### Output
 - Main video: `output_v8_global/news_short_v8_global.mp4`
-- Daily summary: `output_v8_global/daily_summary.mp4`
+- Hindi video: `output_v8_global/news_short_v8_global_hi.mp4`
 
 ## ⚙️ Customization
 

--- a/news_shorts/config.py
+++ b/news_shorts/config.py
@@ -96,9 +96,12 @@ FEED_LIMIT = 15
 
 OUTPUT_DIR = "output_v8_global"
 AUDIO_DIR = os.path.join(OUTPUT_DIR, "audio_segments")
+HINDI_AUDIO_DIR = os.path.join(OUTPUT_DIR, "audio_segments_hi")
 VIDEO_FILE = os.path.join(OUTPUT_DIR, "news_short_v8_global.mp4")
+HINDI_VIDEO_FILE = os.path.join(OUTPUT_DIR, "news_short_v8_global_hi.mp4")
 SUMMARY_FILE = os.path.join(OUTPUT_DIR, "daily_summary.mp4")
 os.makedirs(AUDIO_DIR, exist_ok=True)
+os.makedirs(HINDI_AUDIO_DIR, exist_ok=True)
 
 VIDEO_SIZE = (720, 1280)
 FONT = "Arial"

--- a/news_shorts/pipeline.py
+++ b/news_shorts/pipeline.py
@@ -3,8 +3,8 @@
 from . import config
 from .rss import fetch_all
 from .filtering import filter_stage1, filter_stage2
-from .script_gen import craft_script, craft_daily_summary
-from .video_builder import build_video, build_summary_video
+from .script_gen import craft_script, craft_hindi_script
+from .video_builder import build_video
 from .youtube_client import upload_video
 
 
@@ -15,13 +15,13 @@ def main() -> None:
         arts_1 = filter_stage1(arts_all, top_k=50)
         arts_2 = filter_stage2(arts_1, top_k=20)
         segments = craft_script(arts_2)
-        build_video(segments)
+        build_video(segments, video_path=config.VIDEO_FILE, audio_dir=config.AUDIO_DIR)
         upload_video(config.VIDEO_FILE, arts_2)
 
-        summary_text = craft_daily_summary(arts_2)
-        build_summary_video(summary_text)
-        upload_video(config.SUMMARY_FILE, arts_2, title_prefix="News Summary")
-        config.logger.info(f"🎬 Completed! Video at {config.VIDEO_FILE}")
+        h_segments = craft_hindi_script(arts_2)
+        build_video(h_segments, video_path=config.HINDI_VIDEO_FILE, audio_dir=config.HINDI_AUDIO_DIR)
+        upload_video(config.HINDI_VIDEO_FILE, arts_2, title_prefix="News Shorts Hindi")
+        config.logger.info(f"🎬 Completed! Videos at {config.VIDEO_FILE} and {config.HINDI_VIDEO_FILE}")
     except Exception as exc:
         config.logger.exception(f"Pipeline failed: {exc}")
         raise

--- a/news_shorts/video_builder.py
+++ b/news_shorts/video_builder.py
@@ -11,12 +11,12 @@ from . import config
 from .tts_engine import generate_audio
 
 
-def build_video(segments: List[str]) -> None:
+def build_video(segments: List[str], *, video_path: str = config.VIDEO_FILE, audio_dir: str = config.AUDIO_DIR) -> None:
     config.logger.info("Step 4: Building video over custom background")
     clips = []
     for idx, seg in enumerate(segments):
         config.logger.info(f"  • Segment {idx + 1}/{len(segments)}")
-        audio_fp = os.path.join(config.AUDIO_DIR, f"seg{idx}.mp3")
+        audio_fp = os.path.join(audio_dir, f"seg{idx}.mp3")
         generate_audio(seg, audio_fp)
         aclip = AudioFileClip(audio_fp)
         bg = ImageClip(config.BACKGROUND_IMAGE).set_duration(aclip.duration).set_fps(config.FPS).resize(config.VIDEO_SIZE)
@@ -34,10 +34,10 @@ def build_video(segments: List[str]) -> None:
         clip = CompositeVideoClip([bg, txt]).set_audio(aclip).set_fps(config.FPS)
         clips.append(clip)
     final = concatenate_videoclips(clips, method="compose")
-    config.logger.info(f"Writing video to {config.VIDEO_FILE}")
+    config.logger.info(f"Writing video to {video_path}")
     config.with_retry(
         final.write_videofile,
-        config.VIDEO_FILE,
+        video_path,
         codec="libx264",
         audio_codec="aac",
         fps=config.FPS,


### PR DESCRIPTION
## Summary
- create separate Hindi audio/video directories
- build videos with configurable paths
- craft Hinglish news segments for Hindi shorts
- generate both English and Hindi videos in pipeline
- update README to reflect Hindi shorts and removed summary

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f9a985a4c8320ab06c449886db5a2