### PR TITLE
Resolve dependency conflicts in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ openai==1.76.0
 pillow==9.5.0
 proglog==0.1.11
 proto-plus==1.26.1
-protobuf==6.30.2
+protobuf==5.29.5
 pyasn1==0.6.1
 pyasn1_modules==0.4.2
 pydantic==2.11.3
@@ -49,5 +49,5 @@ typing-inspection==0.4.0
 typing_extensions==4.13.1
 uritemplate==4.1.1
 urllib3==2.2.1
-google-cloud-texttospeech==2.16.2
+google-cloud-texttospeech==2.27.0
 google-generativeai==0.8.5


### PR DESCRIPTION
## Summary
- pin protobuf to a compatible 5.x version
- update Google text-to-speech package to latest

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6862bccdbcbc8320ac1b205c7d379009