### PR TITLE
Add pytest suite and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest -q
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,14 @@ import sys
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
+
+import importlib
+import pytest
+import news_shorts.config as config
+
+
+@pytest.fixture
+def fresh_config():
+    """Reload config module after test to avoid cross-test state."""
+    yield
+    importlib.reload(config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,10 @@
 import importlib
-import os
 import types
 
 import news_shorts.config as config
 
 
-def test_env_overrides(monkeypatch):
+def test_env_overrides(monkeypatch, fresh_config):
     monkeypatch.setenv("VIDEO_WIDTH", "800")
     monkeypatch.setenv("VIDEO_HEIGHT", "600")
     cfg = importlib.reload(config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,41 @@
+import importlib
+import os
+import types
+
+import news_shorts.config as config
+
+
+def test_env_overrides(monkeypatch):
+    monkeypatch.setenv("VIDEO_WIDTH", "800")
+    monkeypatch.setenv("VIDEO_HEIGHT", "600")
+    cfg = importlib.reload(config)
+    assert cfg.VIDEO_SIZE == (800, 600)
+
+
+def test_getenv_helpers(monkeypatch):
+    monkeypatch.delenv("FOO", raising=False)
+    assert config.getenv_int("FOO", 5) == 5
+    monkeypatch.setenv("FOO", "notnum")
+    assert config.getenv_int("FOO", 5) == 5
+    monkeypatch.setenv("BAR", "")
+    assert config.getenv_str("BAR", "baz") == "baz"
+
+
+def test_with_retry(monkeypatch):
+    calls = []
+
+    def flaky(x):
+        calls.append(x)
+        if len(calls) < 3:
+            raise ValueError("fail")
+        return x * 2
+
+    monkeypatch.setattr(config, "RETRY_LIMIT", 3)
+    monkeypatch.setattr(config, "logger", types.SimpleNamespace(info=lambda *a, **k: None,
+                                                                warning=lambda *a, **k: None,
+                                                                error=lambda *a, **k: None))
+    monkeypatch.setattr(config.time, "sleep", lambda x: None)
+    result = config.with_retry(flaky, 5)
+    assert result == 10
+    assert len(calls) == 3
+

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,0 +1,35 @@
+import types
+from news_shorts import filtering
+
+articles = [
+    {"title": "A1", "summary": "S1", "source": "SRC"},
+    {"title": "A2", "summary": "S2", "source": "SRC"},
+    {"title": "A3", "summary": "S3", "source": "SRC"},
+]
+
+class DummyEmb:
+    def __init__(self, emb):
+        self.embedding = emb
+
+def test_filter_stage1(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    data = [DummyEmb([1,1]), DummyEmb([1,1]), DummyEmb([0,1]), DummyEmb([-1,0])]
+    monkeypatch.setattr(filtering.openai.embeddings, 'create', lambda **k: types.SimpleNamespace(data=data))
+    result = filtering.filter_stage1(articles, top_k=2)
+    assert [a['title'] for a in result] == ["A1", "A2"]
+
+
+def test_filter_stage2(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    resp = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='[{"index": 2, "score": 9}, {"index": 0, "score": 8}]'))])
+    monkeypatch.setattr(filtering.openai.chat.completions, 'create', lambda **k: resp)
+    result = filtering.filter_stage2(articles, top_k=2)
+    assert [a['title'] for a in result] == ["A3", "A1"]
+
+
+def test_filter_stage2_bad_json(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    resp = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='oops'))])
+    monkeypatch.setattr(filtering.openai.chat.completions, 'create', lambda **k: resp)
+    result = filtering.filter_stage2(articles, top_k=2)
+    assert [a['title'] for a in result] == ["A1", "A2"]

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,0 +1,31 @@
+import types
+from news_shorts import rss
+from news_shorts import config
+
+
+class DummyFeed:
+    def __init__(self, entries):
+        self.entries = entries
+
+
+def fake_parse(url):
+    if '1' in url:
+        return DummyFeed([
+            {'title': 'T1', 'summary': 'S1', 'link': 'L1', 'published': 'now'},
+            {'title': 'T2', 'summary': 'S2', 'link': 'L2', 'published': 'now'},
+        ])
+    else:
+        return DummyFeed([
+            {'title': 'T1', 'summary': 'S1', 'link': 'L1', 'published': 'now'},
+        ])
+
+
+def test_fetch_all_dedup(monkeypatch):
+    monkeypatch.setattr(rss.feedparser, 'parse', fake_parse)
+    monkeypatch.setitem(config.RSS_SOURCES, 'A', 'url1')
+    monkeypatch.setitem(config.RSS_SOURCES, 'B', 'url2')
+    arts = rss.fetch_all(limit_per_feed=5)
+    assert len(arts) == 2
+    links = {a['link'] for a in arts}
+    assert links == {'L1', 'L2'}
+

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -22,8 +22,7 @@ def fake_parse(url):
 
 def test_fetch_all_dedup(monkeypatch):
     monkeypatch.setattr(rss.feedparser, 'parse', fake_parse)
-    monkeypatch.setitem(config.RSS_SOURCES, 'A', 'url1')
-    monkeypatch.setitem(config.RSS_SOURCES, 'B', 'url2')
+    monkeypatch.setattr(config, 'RSS_SOURCES', {'A': 'url1', 'B': 'url2'})
     arts = rss.fetch_all(limit_per_feed=5)
     assert len(arts) == 2
     links = {a['link'] for a in arts}

--- a/tests/test_script_gen.py
+++ b/tests/test_script_gen.py
@@ -1,0 +1,25 @@
+import types
+from news_shorts import script_gen
+
+articles = [
+    {"title": "T1", "summary": "S1", "source": "SRC"},
+    {"title": "T2", "summary": "S2", "source": "SRC"},
+]
+
+
+def test_craft_script_json(monkeypatch):
+    monkeypatch.setattr(script_gen, "_chat", lambda *a, **k: '{"segments": ["a", "b"]}')
+    segs = script_gen.craft_script(articles)
+    assert segs == ["a", "b"]
+
+
+def test_craft_script_fallback(monkeypatch):
+    monkeypatch.setattr(script_gen, "_chat", lambda *a, **k: 'One. Two.')
+    segs = script_gen.craft_script(articles)
+    assert segs == ["One.", "Two."]
+
+
+def test_craft_daily_summary(monkeypatch):
+    monkeypatch.setattr(script_gen, "_chat", lambda *a, **k: 'summary text')
+    result = script_gen.craft_daily_summary(articles)
+    assert result == 'summary text'

--- a/tests/test_video_builder.py
+++ b/tests/test_video_builder.py
@@ -1,6 +1,4 @@
-import os
 from news_shorts import video_builder as vb
-from news_shorts import tts_engine
 
 
 class DummyClip:
@@ -31,7 +29,6 @@ def dummy_audio(text, path):
 
 def test_build_video_creates_file(tmp_path, monkeypatch):
     out = tmp_path / 'out.mp4'
-    monkeypatch.setattr(tts_engine, 'generate_audio', dummy_audio)
     monkeypatch.setattr(vb, 'generate_audio', dummy_audio)
     monkeypatch.setattr(vb, 'AudioFileClip', lambda p: DummyClip())
     monkeypatch.setattr(vb, 'ImageClip', lambda *a, **k: DummyClip())

--- a/tests/test_video_builder.py
+++ b/tests/test_video_builder.py
@@ -1,0 +1,43 @@
+import os
+from news_shorts import video_builder as vb
+from news_shorts import tts_engine
+
+
+class DummyClip:
+    def __init__(self, *args, **kwargs):
+        self.duration = 1
+        self.h = 10
+    def set_fps(self, fps):
+        return self
+    def resize(self, size):
+        return self
+    def set_audio(self, a):
+        return self
+    def set_position(self, pos):
+        return self
+    def set_duration(self, d):
+        self.duration = d
+        return self
+    def write_videofile(self, path, **kwargs):
+        with open(path, 'wb') as f:
+            f.write(b'')
+        return path
+
+
+def dummy_audio(text, path):
+    with open(path, 'wb') as f:
+        f.write(b'0')
+
+
+def test_build_video_creates_file(tmp_path, monkeypatch):
+    out = tmp_path / 'out.mp4'
+    monkeypatch.setattr(tts_engine, 'generate_audio', dummy_audio)
+    monkeypatch.setattr(vb, 'generate_audio', dummy_audio)
+    monkeypatch.setattr(vb, 'AudioFileClip', lambda p: DummyClip())
+    monkeypatch.setattr(vb, 'ImageClip', lambda *a, **k: DummyClip())
+    monkeypatch.setattr(vb, 'TextClip', lambda *a, **k: DummyClip())
+    monkeypatch.setattr(vb, 'CompositeVideoClip', lambda clips: DummyClip())
+    monkeypatch.setattr(vb, 'concatenate_videoclips', lambda clips, method='compose': DummyClip())
+    vb.build_video(['hello'], video_path=str(out), audio_dir=str(tmp_path))
+    assert out.exists()
+


### PR DESCRIPTION
## Summary
- add simple tests for config, RSS fetching, and video builder
- set up path fixture for tests
- run pytest on every push with GitHub Actions
- expand test coverage to script generation and filtering modules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868537e2b688320a8d4134f38fd1f88