### PR TITLE
Add local embedding option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ ELEVENLABS_VOICE_ID=your_voice_id
 GEN_AI_PROVIDER=openai          # openai or google
 TTS_PROVIDER=openai             # openai, elevenlabs or google
 
+# Embedding options
+EMBED_PROVIDER=openai           # openai or local
+LOCAL_EMBED_MODEL=sentence-transformers/all-MiniLM-L6-v2
+
 # Text-to-speech options
 TTS_MODEL=tts-1-hd              # OpenAI model
 TTS_VOICE=ash                   # Voice name

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Most behaviour can be configured with env vars or a `.env` file. Important optio
 - If a variable is set but left blank, the app falls back to its default value.
 - `GEN_AI_PROVIDER` chooses `openai` or `google` for script generation.
 - `TTS_PROVIDER` selects `openai`, `elevenlabs` or `google` for speech.
+- `EMBED_PROVIDER` selects `openai` or `local` for article embeddings.
 - `VIDEO_LANGUAGES` sets which videos to make (e.g. `en,hi`).
 - `UPLOAD_TO_YOUTUBE` set `0` to skip uploading.
 - `OUTPUT_DIR` and `FILE_PREFIX` control where files are written.
@@ -143,6 +144,8 @@ See `.env.example` for the full list. You can also pass these variables via the 
 | `TTS_PROVIDER` | `openai`, `elevenlabs` or `google` | `openai` |
 | `TTS_MODEL` | OpenAI speech model | `tts-1-hd` |
 | `TTS_VOICE` | Voice name for OpenAI or ElevenLabs | `ash` |
+| `EMBED_PROVIDER` | `openai` or `local` | `openai` |
+| `LOCAL_EMBED_MODEL` | SentenceTransformer model name | `sentence-transformers/all-MiniLM-L6-v2` |
 | `GOOGLE_TTS_LANGUAGE` | Google TTS language code | `en-US` |
 | `SPEEDUP` | Audio playback speed | `1.1` |
 | `VIDEO_LANGUAGES` | Languages to produce (`en`, `hi`) | `en,hi` |

--- a/news_shorts/config.py
+++ b/news_shorts/config.py
@@ -53,6 +53,12 @@ if TTS_PROVIDER == "elevenlabs" and not (ELEVENLABS_API_KEY and ELEVENLABS_VOICE
 USE_ELEVENLABS = TTS_PROVIDER == "elevenlabs"
 USE_GOOGLE_TTS = TTS_PROVIDER == "google"
 
+# Embedding provider for filtering
+EMBED_PROVIDER = getenv_str("EMBED_PROVIDER", "openai").lower()
+LOCAL_EMBED_MODEL = getenv_str(
+    "LOCAL_EMBED_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
+)
+
 # YouTube credentials from environment
 YOUTUBE_CLIENT_ID = os.getenv("YOUTUBE_CLIENT_ID")
 YOUTUBE_CLIENT_SECRET = os.getenv("YOUTUBE_CLIENT_SECRET")

--- a/news_shorts/filtering.py
+++ b/news_shorts/filtering.py
@@ -3,6 +3,7 @@ from typing import List, Dict
 import numpy as np
 import openai
 from . import config
+from . import local_llm
 
 Article = Dict[str, str]
 
@@ -14,10 +15,16 @@ def filter_stage1(articles: List[Article], top_k: int = 50) -> List[Article]:
     config.logger.info("Phase 1: Semantic filtering via embeddings")
     seed = "India politics commerce sports technology entertainment"
     texts = [seed] + [f"{a['title']} {a['summary']}" for a in articles]
-    resp = config.with_retry(openai.embeddings.create, model="text-embedding-ada-002", input=texts)
-    embs = resp.data
-    seed_emb = np.array(embs[0].embedding)
-    art_embs = np.array([e.embedding for e in embs[1:]])
+    if config.EMBED_PROVIDER == "local":
+        embs = local_llm.embed_texts(texts)
+        seed_emb = np.array(embs[0])
+        art_embs = np.array(embs[1:])
+    else:
+        resp = config.with_retry(
+            openai.embeddings.create, model="text-embedding-ada-002", input=texts
+        )
+        seed_emb = np.array(resp.data[0].embedding)
+        art_embs = np.array([e.embedding for e in resp.data[1:]])
     norms = np.linalg.norm(art_embs, axis=1) * np.linalg.norm(seed_emb)
     sims = (art_embs @ seed_emb) / norms
     idxs = np.argsort(-sims)[:top_k]

--- a/news_shorts/local_llm.py
+++ b/news_shorts/local_llm.py
@@ -1,0 +1,20 @@
+from functools import lru_cache
+from typing import List
+
+from sentence_transformers import SentenceTransformer
+
+from . import config
+
+
+@lru_cache(maxsize=1)
+def _load_model() -> SentenceTransformer:
+    model_name = config.LOCAL_EMBED_MODEL
+    config.logger.info(f"Loading local embed model: {model_name}")
+    return SentenceTransformer(model_name)
+
+
+def embed_texts(texts: List[str]) -> List[List[float]]:
+    """Return vector embeddings for given texts using a local model."""
+    model = _load_model()
+    emb = model.encode(texts, show_progress_bar=False)
+    return emb.tolist()

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,6 @@ uritemplate==4.1.1
 urllib3==2.2.1
 google-cloud-texttospeech==2.27.0
 google-generativeai==0.8.5
+sentence-transformers==2.6.1
+transformers==4.38.1
+torch==2.2.2


### PR DESCRIPTION
## Summary
- add new optional EMBED_PROVIDER env var for choosing local embeddings
- support SentenceTransformers embeddings via `local_llm.py`
- update filtering to use local embeddings when configured
- document new settings in README and `.env.example`
- add transformers, torch and sentence-transformers to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687164fbff5c83208e23aef1aee33c83