### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -292,3 +292,17 @@ Stay updated with the latest features and improvements by:
 ---
 
 **Note**: This application requires active API keys and internet connectivity to function properly. Ensure you have sufficient API credits before running the script. 
+
+## 🐳 Docker Deployment
+
+Build the Docker image:
+```bash
+docker build -t vyapar-backend .
+```
+
+Run the container exposing port 8000:
+```bash
+docker run -p 8000:8000 vyapar-backend
+```
+
+The application will be available at `http://localhost:8000/`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Welcome to TheDailySnap backend"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,6 @@ uritemplate==4.1.1
 urllib3==2.2.1
 google-cloud-texttospeech==2.27.0
 google-generativeai==0.8.5
+
+fastapi==0.110.2
+uvicorn==0.29.0


### PR DESCRIPTION
## Summary
- add FastAPI backend skeleton
- create Dockerfile for running the backend with Uvicorn
- document Docker usage
- add FastAPI and Uvicorn to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- *(failure: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687551505df483208e00f2655827eae3